### PR TITLE
Corrige le nom des rôles dans l'export d'utilisateurs

### DIFF
--- a/src/Service/Exporter/UserExporter.php
+++ b/src/Service/Exporter/UserExporter.php
@@ -70,6 +70,8 @@ class UserExporter extends ExporterService
             $rolesName[] = match ($role) {
                 'ROLE_USER' => 'Utilisateur',
                 'ROLE_ADMIN' => 'Administrateur',
+                'ROLE_MEMBER' => 'Adhérent',
+                'ROLE_PARTNER' => 'Partenaire',
                 default => $role,
             };
         }


### PR DESCRIPTION
Il manquait les traductions pour ROLE_MEMBER et ROLE_PARTNER